### PR TITLE
Add full server & api proxy with nginx & docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,3 +15,6 @@ jobs:
           echo "${DOCKERHUB_PASS}" | docker login --username "${DOCKERHUB_USER}" --password-stdin
           docker build --tag "${DOCKERHUB_USER}/global-streaming-search:latest" .
           docker push "${DOCKERHUB_USER}/global-streaming-search:latest"
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,27 @@
-FROM node:lts-alpine
+FROM alpine:3.16
 
 EXPOSE 8000/tcp
 
+RUN apk update \
+  && apk add npm nginx
+
 ADD . "/app"
-WORKDIR /app
 
-RUN npm install
-RUN npm run build
+RUN cd /app \
+  # Build the app
+  && npm install \
+  && API_PROXY='/api' npm run build \
+  # Save the build so nginx can serve it
+  && cp -r /app/public /var/www/ \
+  # Add the nginx configuration
+  && cp /app/docker/nginx.conf /etc/nginx/nginx.conf \
+  # Create a directory for nginx to cache API responses
+  && mkdir -p /var/cache/nginx \
+  # We don't need to keep the app files after we have the build
+  && rm -rf /app \
+  # We don't need npm after we have the build
+  && apk del npm \
+  # We also don't need the apk cache, we won't be installing any more packages
+  && rm -rf /var/cache/apk/
 
-ENTRYPOINT [ "npm", "run", "start" ]
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,47 @@
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  access_log /var/log/nginx/access.log;
+  sendfile on;
+  keepalive_timeout 65;
+  gzip on;
+
+  proxy_cache_path /var/cache/nginx keys_zone=api_proxy:10m;
+
+  server {
+    listen 8000;
+
+    root /var/www/public/;
+
+    add_header Referrer-Policy "no-referrer" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Download-Options "noopen" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header X-Robots-Tag "none" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    location /api/ {
+      proxy_cache api_proxy;
+      proxy_cache_lock on;
+
+      proxy_pass https://apis.justwatch.com/;
+
+    }
+
+    location / {
+      try_files $uri $uri/ =404;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
+        "@rollup/plugin-replace": "^5.0.1",
         "@rollup/plugin-typescript": "^8.0.0",
         "@tsconfig/svelte": "^2.0.0",
         "rollup": "^2.3.4",
@@ -199,6 +200,67 @@
       },
       "peerDependencies": {
         "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.1.tgz",
+      "integrity": "sha512-Z3MfsJ4CK17BfGrZgvrcp/l6WXoKb0kokULO+zt/7bmcyayokDaQ2K3eDJcRLCTAlp5FPI4/gz9MHAsosz4Rag==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.26.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -971,9 +1033,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -1762,6 +1824,44 @@
         "resolve": "^1.19.0"
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.1.tgz",
+      "integrity": "sha512-Z3MfsJ4CK17BfGrZgvrcp/l6WXoKb0kokULO+zt/7bmcyayokDaQ2K3eDJcRLCTAlp5FPI4/gz9MHAsosz4Rag==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.26.4"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+          "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^2.3.1"
+          }
+        },
+        "@types/estree": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+          "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+          "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        }
+      }
+    },
     "@rollup/plugin-typescript": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.0.tgz",
@@ -2363,9 +2463,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
+    "@rollup/plugin-replace": "^5.0.1",
     "@rollup/plugin-typescript": "^8.0.0",
     "@tsconfig/svelte": "^2.0.0",
     "rollup": "^2.3.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 import sveltePreprocess from 'svelte-preprocess';
 import typescript from '@rollup/plugin-typescript';
 import css from 'rollup-plugin-css-only';
+import replace from '@rollup/plugin-replace';
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -49,6 +50,14 @@ export default {
 		// we'll extract any component CSS out into
 		// a separate file - better for performance
 		css({ output: 'bundle.css' }),
+
+		// Add API proxy URL if available
+		replace({
+			preventAssignment: true,
+			values: {
+				'process.env.API_PROXY': `"${process.env.API_PROXY}"` ?? 'undefined',
+			}
+		}),
 
 		// If you have external dependencies installed from
 		// npm, you'll most likely need these plugins. In

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,7 +55,7 @@ export default {
 		replace({
 			preventAssignment: true,
 			values: {
-				'process.env.API_PROXY': `"${process.env.API_PROXY}"` ?? 'undefined',
+				'process.env.API_PROXY': process.env.API_PROXY ? `"${process.env.API_PROXY}"` : undefined,
 			}
 		}),
 

--- a/src/backend/justwatchapi.ts
+++ b/src/backend/justwatchapi.ts
@@ -2,8 +2,15 @@
 
 import { all_locales, all_providers } from "./data"
 
+/** The API base url to use.
+ * 
+ * This is set by the `API_PROXY` environment variable during build if available. otherwise
+ * defaults to directly accessing the API.
+ */
+const API_BASE = process.env.API_PROXY ?? "https://apis.justwatch.com";
+
 export async function search_for_item(query: string, country: string): Promise<any> {
-    const url = `https://apis.justwatch.com/content/titles/${country}/popular`
+    const url = `${API_BASE}/content/titles/${country}/popular`
 
     const body = {
         "query": query,
@@ -58,7 +65,7 @@ export async function get_all_locales(): Promise<[Locale]> {
 
 // Returns JSON data on every provider JustWatch has data on for a given locale/country
 async function get_providers(country: string): Promise<any> {
-    const url = `https://apis.justwatch.com/content/providers/locale/${country}`
+    const url = `${API_BASE}/content/providers/locale/${country}`
     const response = await fetch(url, {
       headers: {"X-Requested-With": "fetch"}
     })
@@ -88,7 +95,7 @@ Returns JustWatch's data for a given show or movie for a given locale.
 content_type is either "show" or "movie"
 */
 export async function get_title_from_id(title_id: string, country: string, content_type: string): Promise<any> {
-    const url = `https://apis.justwatch.com/content/titles/${content_type}/${title_id}/locale/${country}`
+    const url = `${API_BASE}/content/titles/${content_type}/${title_id}/locale/${country}`
     const response = await fetch(url, {
       headers: {"X-Requested-With": "fetch"}
     })


### PR DESCRIPTION
This PR updates the docker file to set up nginx, which is then used both to serve the public assets and to proxy the API. The API proxy also performs caching which speeds up future requests.

To easily switch between directly querying the justwatch API and using the nginx proxy, I also added a way to set the API base url using environment variables during build.