### PR TITLE
Autofocus on search box

### DIFF
--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -44,6 +44,7 @@
                 bind:value={query}
                 placeholder="🔎 Title"
                 style="width: 40vw; height: 2.5rem;"
+                autofocus
               />
               <input type="submit" class="search" value="Search" />
             </div>


### PR DESCRIPTION
Small UX improvement (in my opinion): autofocus on the search box when the page loads, so the user can immediately start typing. This avoids having to click on the search box. Especially useful if you do multiple searches in a short time frame.

![image](https://github.com/Colaski/global-streaming-search/assets/3625477/3e07b505-5fd1-407e-9a5f-17fb470fd78a)
